### PR TITLE
use error return code in place of assert()

### DIFF
--- a/src/libinjection.h
+++ b/src/libinjection.h
@@ -24,6 +24,7 @@ LIBINJECTION_BEGIN_DECLS
  * Pull in size_t
  */
 #include <string.h>
+#include "libinjection_html5.h"
 
 /*
  * Version info.
@@ -58,7 +59,7 @@ int libinjection_sqli(const char* s, size_t slen, char fingerprint[]);
  * \return 1 if XSS found, 0 if benign
  *
  */
-int libinjection_xss(const char* s, size_t slen);
+injection_result_t libinjection_xss(const char *s, size_t slen);
 
 LIBINJECTION_END_DECLS
 

--- a/src/libinjection_html5.c
+++ b/src/libinjection_html5.c
@@ -29,35 +29,35 @@
 
 static int h5_skip_white(h5_state_t* hs);
 static int h5_is_white(char ch);
-static tri_result_t h5_state_eof(h5_state_t* hs);
-static tri_result_t h5_state_data(h5_state_t* hs);
-static tri_result_t h5_state_tag_open(h5_state_t* hs);
-static tri_result_t h5_state_tag_name(h5_state_t* hs);
-static tri_result_t h5_state_tag_name_close(h5_state_t* hs);
-static tri_result_t h5_state_end_tag_open(h5_state_t* hs);
-static tri_result_t h5_state_self_closing_start_tag(h5_state_t* hs);
-static tri_result_t h5_state_attribute_name(h5_state_t* hs);
-static tri_result_t h5_state_after_attribute_name(h5_state_t* hs);
-static tri_result_t h5_state_before_attribute_name(h5_state_t* hs);
-static tri_result_t h5_state_before_attribute_value(h5_state_t* hs);
-static tri_result_t h5_state_attribute_value_double_quote(h5_state_t* hs);
-static tri_result_t h5_state_attribute_value_single_quote(h5_state_t* hs);
-static tri_result_t h5_state_attribute_value_back_quote(h5_state_t* hs);
-static tri_result_t h5_state_attribute_value_no_quote(h5_state_t* hs);
-static tri_result_t h5_state_after_attribute_value_quoted_state(h5_state_t* hs);
-static tri_result_t h5_state_comment(h5_state_t* hs);
-static tri_result_t h5_state_cdata(h5_state_t* hs);
+static injection_result_t h5_state_eof(h5_state_t* hs);
+static injection_result_t h5_state_data(h5_state_t* hs);
+static injection_result_t h5_state_tag_open(h5_state_t* hs);
+static injection_result_t h5_state_tag_name(h5_state_t* hs);
+static injection_result_t h5_state_tag_name_close(h5_state_t* hs);
+static injection_result_t h5_state_end_tag_open(h5_state_t* hs);
+static injection_result_t h5_state_self_closing_start_tag(h5_state_t* hs);
+static injection_result_t h5_state_attribute_name(h5_state_t* hs);
+static injection_result_t h5_state_after_attribute_name(h5_state_t* hs);
+static injection_result_t h5_state_before_attribute_name(h5_state_t* hs);
+static injection_result_t h5_state_before_attribute_value(h5_state_t* hs);
+static injection_result_t h5_state_attribute_value_double_quote(h5_state_t* hs);
+static injection_result_t h5_state_attribute_value_single_quote(h5_state_t* hs);
+static injection_result_t h5_state_attribute_value_back_quote(h5_state_t* hs);
+static injection_result_t h5_state_attribute_value_no_quote(h5_state_t* hs);
+static injection_result_t h5_state_after_attribute_value_quoted_state(h5_state_t* hs);
+static injection_result_t h5_state_comment(h5_state_t* hs);
+static injection_result_t h5_state_cdata(h5_state_t* hs);
 
 
 /* 12.2.4.44 */
-static tri_result_t h5_state_bogus_comment(h5_state_t* hs);
-static tri_result_t h5_state_bogus_comment2(h5_state_t* hs);
+static injection_result_t h5_state_bogus_comment(h5_state_t* hs);
+static injection_result_t h5_state_bogus_comment2(h5_state_t* hs);
 
 /* 12.2.4.45 */
-static tri_result_t h5_state_markup_declaration_open(h5_state_t* hs);
+static injection_result_t h5_state_markup_declaration_open(h5_state_t* hs);
 
 /* 8.2.4.52 */
-static tri_result_t h5_state_doctype(h5_state_t* hs);
+static injection_result_t h5_state_doctype(h5_state_t* hs);
 
 /**
  * public function
@@ -90,7 +90,7 @@ void libinjection_h5_init(h5_state_t* hs, const char* s, size_t len, enum html5_
 /**
  * public function
  */
-tri_result_t libinjection_h5_next(h5_state_t* hs)
+injection_result_t libinjection_h5_next(h5_state_t* hs)
 {
     if (hs->state == NULL) {
         return RESULT_ERROR;
@@ -138,14 +138,14 @@ static int h5_skip_white(h5_state_t* hs)
     return CHAR_EOF;
 }
 
-static tri_result_t h5_state_eof(h5_state_t* hs)
+static injection_result_t h5_state_eof(h5_state_t* hs)
 {
     /* eliminate unused function argument warning */
     (void)hs;
     return RESULT_FALSE;
 }
 
-static tri_result_t h5_state_data(h5_state_t* hs)
+static injection_result_t h5_state_data(h5_state_t* hs)
 {
     const char* idx;
 
@@ -179,7 +179,7 @@ static tri_result_t h5_state_data(h5_state_t* hs)
 /**
  * 12 2.4.8
  */
-static tri_result_t h5_state_tag_open(h5_state_t* hs)
+static injection_result_t h5_state_tag_open(h5_state_t* hs)
 {
     char ch;
 
@@ -223,7 +223,7 @@ static tri_result_t h5_state_tag_open(h5_state_t* hs)
 /**
  * 12.2.4.9
  */
-static tri_result_t h5_state_end_tag_open(h5_state_t* hs)
+static injection_result_t h5_state_end_tag_open(h5_state_t* hs)
 {
     char ch;
 
@@ -245,7 +245,7 @@ static tri_result_t h5_state_end_tag_open(h5_state_t* hs)
 /*
  *
  */
-static tri_result_t h5_state_tag_name_close(h5_state_t* hs)
+static injection_result_t h5_state_tag_name_close(h5_state_t* hs)
 {
     TRACE();
     hs->is_close = 0;
@@ -265,7 +265,7 @@ static tri_result_t h5_state_tag_name_close(h5_state_t* hs)
 /**
  * 12.2.4.10
  */
-static tri_result_t h5_state_tag_name(h5_state_t* hs)
+static injection_result_t h5_state_tag_name(h5_state_t* hs)
 {
     char ch;
     size_t pos;
@@ -322,7 +322,7 @@ static tri_result_t h5_state_tag_name(h5_state_t* hs)
 /**
  * 12.2.4.34
  */
-static tri_result_t h5_state_before_attribute_name(h5_state_t* hs)
+static injection_result_t h5_state_before_attribute_name(h5_state_t* hs)
 {
     int ch;
 
@@ -350,7 +350,7 @@ static tri_result_t h5_state_before_attribute_name(h5_state_t* hs)
     }
 }
 
-static tri_result_t h5_state_attribute_name(h5_state_t* hs)
+static injection_result_t h5_state_attribute_name(h5_state_t* hs)
 {
     char ch;
     size_t pos;
@@ -403,7 +403,7 @@ static tri_result_t h5_state_attribute_name(h5_state_t* hs)
 /**
  * 12.2.4.36
  */
-static tri_result_t h5_state_after_attribute_name(h5_state_t* hs)
+static injection_result_t h5_state_after_attribute_name(h5_state_t* hs)
 {
     int c;
 
@@ -433,7 +433,7 @@ static tri_result_t h5_state_after_attribute_name(h5_state_t* hs)
 /**
  * 12.2.4.37
  */
-static tri_result_t h5_state_before_attribute_value(h5_state_t* hs)
+static injection_result_t h5_state_before_attribute_value(h5_state_t* hs)
 {
     int c;
     TRACE();
@@ -458,7 +458,7 @@ static tri_result_t h5_state_before_attribute_value(h5_state_t* hs)
 }
 
 
-static tri_result_t h5_state_attribute_value_quote(h5_state_t* hs, char qchar)
+static injection_result_t h5_state_attribute_value_quote(h5_state_t* hs, char qchar)
 {
     const char* idx;
 
@@ -491,27 +491,27 @@ static tri_result_t h5_state_attribute_value_quote(h5_state_t* hs, char qchar)
 }
 
 static
-tri_result_t h5_state_attribute_value_double_quote(h5_state_t* hs)
+injection_result_t h5_state_attribute_value_double_quote(h5_state_t* hs)
 {
     TRACE();
     return h5_state_attribute_value_quote(hs, CHAR_DOUBLE);
 }
 
 static
-tri_result_t h5_state_attribute_value_single_quote(h5_state_t* hs)
+injection_result_t h5_state_attribute_value_single_quote(h5_state_t* hs)
 {
     TRACE();
     return h5_state_attribute_value_quote(hs, CHAR_SINGLE);
 }
 
 static
-tri_result_t h5_state_attribute_value_back_quote(h5_state_t* hs)
+injection_result_t h5_state_attribute_value_back_quote(h5_state_t* hs)
 {
     TRACE();
     return h5_state_attribute_value_quote(hs, CHAR_TICK);
 }
 
-static tri_result_t h5_state_attribute_value_no_quote(h5_state_t* hs)
+static injection_result_t h5_state_attribute_value_no_quote(h5_state_t* hs)
 {
     char ch;
     size_t pos;
@@ -549,7 +549,7 @@ static tri_result_t h5_state_attribute_value_no_quote(h5_state_t* hs)
 /**
  * 12.2.4.41
  */
-static tri_result_t h5_state_after_attribute_value_quoted_state(h5_state_t* hs)
+static injection_result_t h5_state_after_attribute_value_quoted_state(h5_state_t* hs)
 {
     char ch;
 
@@ -579,7 +579,7 @@ static tri_result_t h5_state_after_attribute_value_quoted_state(h5_state_t* hs)
 /**
  * 12.2.4.43
  */
-static tri_result_t h5_state_self_closing_start_tag(h5_state_t* hs)
+static injection_result_t h5_state_self_closing_start_tag(h5_state_t* hs)
 {
     char ch;
 
@@ -606,7 +606,7 @@ static tri_result_t h5_state_self_closing_start_tag(h5_state_t* hs)
 /**
  * 12.2.4.44
  */
-static tri_result_t h5_state_bogus_comment(h5_state_t* hs)
+static injection_result_t h5_state_bogus_comment(h5_state_t* hs)
 {
     const char* idx;
 
@@ -631,7 +631,7 @@ static tri_result_t h5_state_bogus_comment(h5_state_t* hs)
 /**
  * 12.2.4.44 ALT
  */
-static tri_result_t h5_state_bogus_comment2(h5_state_t* hs)
+static injection_result_t h5_state_bogus_comment2(h5_state_t* hs)
 {
     const char* idx;
     size_t pos;
@@ -667,7 +667,7 @@ static tri_result_t h5_state_bogus_comment2(h5_state_t* hs)
 /**
  * 8.2.4.45
  */
-static tri_result_t h5_state_markup_declaration_open(h5_state_t* hs)
+static injection_result_t h5_state_markup_declaration_open(h5_state_t* hs)
 {
     size_t remaining;
 
@@ -717,7 +717,7 @@ static tri_result_t h5_state_markup_declaration_open(h5_state_t* hs)
  *   2) ending in -->
  *   3) ending in -!>
  */
-static tri_result_t h5_state_comment(h5_state_t* hs)
+static injection_result_t h5_state_comment(h5_state_t* hs)
 {
     char ch;
     const char* idx;
@@ -801,7 +801,7 @@ static tri_result_t h5_state_comment(h5_state_t* hs)
     }
 }
 
-static tri_result_t h5_state_cdata(h5_state_t* hs)
+static injection_result_t h5_state_cdata(h5_state_t* hs)
 {
     const char* idx;
     size_t pos;
@@ -835,7 +835,7 @@ static tri_result_t h5_state_cdata(h5_state_t* hs)
  * 8.2.4.52
  * http://www.w3.org/html/wg/drafts/html/master/syntax.html#doctype-state
  */
-static tri_result_t h5_state_doctype(h5_state_t* hs)
+static injection_result_t h5_state_doctype(h5_state_t* hs)
 {
     const char* idx;
 

--- a/src/libinjection_html5.h
+++ b/src/libinjection_html5.h
@@ -9,6 +9,12 @@ extern "C" {
 
 #include <stddef.h>
 
+typedef enum tri_result {
+    RESULT_FALSE
+    , RESULT_TRUE
+    , RESULT_ERROR
+} tri_result_t;
+
 enum html5_type {
     DATA_TEXT
     , TAG_NAME_OPEN
@@ -31,7 +37,7 @@ enum html5_flags {
 };
 
 struct h5_state;
-typedef int (*ptr_html5_state)(struct h5_state*);
+typedef tri_result_t (*ptr_html5_state)(struct h5_state*);
 
 typedef struct h5_state {
     const char* s;
@@ -45,8 +51,10 @@ typedef struct h5_state {
 } h5_state_t;
 
 
+
+
 void libinjection_h5_init(h5_state_t* hs, const char* s, size_t len, enum html5_flags);
-int libinjection_h5_next(h5_state_t* hs);
+tri_result_t libinjection_h5_next(h5_state_t* hs);
 
 #ifdef __cplusplus
 }

--- a/src/libinjection_html5.h
+++ b/src/libinjection_html5.h
@@ -9,11 +9,11 @@ extern "C" {
 
 #include <stddef.h>
 
-typedef enum tri_result {
-    RESULT_FALSE
-    , RESULT_TRUE
-    , RESULT_ERROR
-} tri_result_t;
+typedef enum injection_result_t {
+    RESULT_FALSE = 0,
+    RESULT_TRUE = 1,
+    RESULT_ERROR = -1
+} injection_result_t;
 
 enum html5_type {
     DATA_TEXT
@@ -37,7 +37,7 @@ enum html5_flags {
 };
 
 struct h5_state;
-typedef tri_result_t (*ptr_html5_state)(struct h5_state*);
+typedef injection_result_t (*ptr_html5_state)(struct h5_state*);
 
 typedef struct h5_state {
     const char* s;
@@ -54,7 +54,7 @@ typedef struct h5_state {
 
 
 void libinjection_h5_init(h5_state_t* hs, const char* s, size_t len, enum html5_flags);
-tri_result_t libinjection_h5_next(h5_state_t* hs);
+injection_result_t libinjection_h5_next(h5_state_t* hs);
 
 #ifdef __cplusplus
 }

--- a/src/libinjection_xss.c
+++ b/src/libinjection_xss.c
@@ -247,8 +247,8 @@ static int cstrcasecmp_with_null(const char *a, const char *b, size_t n)
  *
  * return 1 if match / starts with
  * return 0 if not
- */
-static int htmlencode_startswith(const char *a, const char *b, size_t n)
+ */                            /*const char* prefix, const char *src, size_t n*/
+static int htmlencode_startswith(const char *a,      const char *b,   size_t n)
 {
     size_t consumed;
     int cb;
@@ -415,9 +415,10 @@ int libinjection_is_xss(const char* s, size_t len, int flags)
 {
     h5_state_t h5;
     attribute_t attr = TYPE_NONE;
+    tri_result_t parser_result;
 
     libinjection_h5_init(&h5, s, len, (enum html5_flags) flags);
-    while (libinjection_h5_next(&h5)) {
+    while ((parser_result = libinjection_h5_next(&h5)) == RESULT_TRUE) {
         if (h5.token_type != ATTR_VALUE) {
             attr = TYPE_NONE;
         }
@@ -502,6 +503,9 @@ int libinjection_is_xss(const char* s, size_t len, int flags)
                 }
             }
         }
+    }
+    if (parser_result == RESULT_ERROR) {
+        /* todo: log*/
     }
     return 0;
 }

--- a/src/libinjection_xss.c
+++ b/src/libinjection_xss.c
@@ -411,11 +411,11 @@ static int is_black_url(const char* s, size_t len)
     return 0;
 }
 
-int libinjection_is_xss(const char* s, size_t len, int flags)
+injection_result_t libinjection_is_xss(const char *s, size_t len, int flags)
 {
     h5_state_t h5;
     attribute_t attr = TYPE_NONE;
-    tri_result_t parser_result;
+    injection_result_t parser_result;
 
     libinjection_h5_init(&h5, s, len, (enum html5_flags) flags);
     while ((parser_result = libinjection_h5_next(&h5)) == RESULT_TRUE) {
@@ -424,10 +424,10 @@ int libinjection_is_xss(const char* s, size_t len, int flags)
         }
 
         if (h5.token_type == DOCTYPE) {
-            return 1;
+            return RESULT_TRUE;
         } else if (h5.token_type == TAG_NAME_OPEN) {
             if (is_black_tag(h5.token_start, h5.token_len)) {
-                return 1;
+                return RESULT_TRUE;
             }
         } else if (h5.token_type == ATTR_NAME) {
             attr = is_black_attr(h5.token_start, h5.token_len);
@@ -451,18 +451,18 @@ int libinjection_is_xss(const char* s, size_t len, int flags)
             case TYPE_NONE:
                 break;
             case TYPE_BLACK:
-                return 1;
+                return RESULT_TRUE;
             case TYPE_ATTR_URL:
                 if (is_black_url(h5.token_start, h5.token_len)) {
-                    return 1;
+                    return RESULT_TRUE;
                 }
                 break;
             case TYPE_STYLE:
-                return 1;
+                return RESULT_TRUE;
             case TYPE_ATTR_INDIRECT:
                 /* an attribute name is specified in a _value_ */
                 if (is_black_attr(h5.token_start, h5.token_len)) {
-                    return 1;
+                    return RESULT_TRUE;
                 }
                 break;
 /*
@@ -474,7 +474,7 @@ int libinjection_is_xss(const char* s, size_t len, int flags)
         } else if (h5.token_type == TAG_COMMENT) {
             /* IE uses a "`" as a tag ending char */
             if (memchr(h5.token_start, '`', h5.token_len) != NULL) {
-                return 1;
+                return RESULT_TRUE;
             }
 
             /* IE conditional comment */
@@ -482,55 +482,52 @@ int libinjection_is_xss(const char* s, size_t len, int flags)
                 if (h5.token_start[0] == '[' &&
                     (h5.token_start[1] == 'i' || h5.token_start[1] == 'I') &&
                     (h5.token_start[2] == 'f' || h5.token_start[2] == 'F')) {
-                    return 1;
+                    return RESULT_TRUE;
                 }
                 if ((h5.token_start[0] == 'x' || h5.token_start[0] == 'X') &&
                     (h5.token_start[1] == 'm' || h5.token_start[1] == 'M') &&
                     (h5.token_start[2] == 'l' || h5.token_start[2] == 'L')) {
-                    return 1;
+                    return RESULT_TRUE;
                 }
             }
 
             if (h5.token_len > 5) {
                 /*  IE <?import pseudo-tag */
                 if (cstrcasecmp_with_null("IMPORT", h5.token_start, 6) == 0) {
-                    return 1;
+                    return RESULT_TRUE;
                 }
 
                 /*  XML Entity definition */
                 if (cstrcasecmp_with_null("ENTITY", h5.token_start, 6) == 0) {
-                    return 1;
+                    return RESULT_TRUE;
                 }
             }
         }
     }
-    if (parser_result == RESULT_ERROR) {
-        /* todo: log*/
-    }
-    return 0;
+    return parser_result;
 }
 
 
 /*
  * wrapper
  */
-int libinjection_xss(const char* s, size_t len)
-{
-    if (libinjection_is_xss(s, len, DATA_STATE)) {
-        return 1;
+injection_result_t libinjection_xss(const char *s, size_t len) {
+    injection_result_t result;
+    if ((result = libinjection_is_xss(s, len, DATA_STATE)) != RESULT_FALSE) {
+        return result;
     }
-    if (libinjection_is_xss(s, len, VALUE_NO_QUOTE)) {
-        return 1;
+    if ((result = libinjection_is_xss(s, len, VALUE_NO_QUOTE)) != RESULT_FALSE) {
+        return result;
     }
-    if (libinjection_is_xss(s, len, VALUE_SINGLE_QUOTE)) {
-        return 1;
+    if ((result = libinjection_is_xss(s, len, VALUE_SINGLE_QUOTE)) != RESULT_FALSE) {
+        return result;
     }
-    if (libinjection_is_xss(s, len, VALUE_DOUBLE_QUOTE)) {
-        return 1;
+    if ((result = libinjection_is_xss(s, len, VALUE_DOUBLE_QUOTE)) != RESULT_FALSE) {
+        return result;
     }
-    if (libinjection_is_xss(s, len, VALUE_BACK_QUOTE)) {
-        return 1;
+    if ((result = libinjection_is_xss(s, len, VALUE_BACK_QUOTE)) != RESULT_FALSE) {
+        return result;
     }
 
-    return 0;
+    return RESULT_FALSE;
 }

--- a/src/libinjection_xss.h
+++ b/src/libinjection_xss.h
@@ -12,8 +12,9 @@ extern "C" {
 /* pull in size_t */
 
 #include <string.h>
+#include "libinjection_html5.h"
 
-  int libinjection_is_xss(const char* s, size_t len, int flags);
+injection_result_t libinjection_is_xss(const char *s, size_t len, int flags);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
`libinjection_xss()` is basically a FSM parser for HTML tokens.   It parses elements and attributes and compares them against a list of known XSS strings.   (I'm glossing over things a bit, it also handles malformed tags and embedded nulls and other shenanigans) 
  
Originally, `libinjection_xss()` would return an int to indicate evidence of XSS (1) or  absence (0).  If the parser's state machine wound up in a bad state (e.g. string cursor position greater than string length), libinjection would abort the process it was in.

This change creates an enum return type for `libinjection_xss()` and downstream state functions that indicates XSS True, False or Error.  The Error return code indicates the parser state machine got into a bad state.   The library will no longer abort on error.